### PR TITLE
Add intro feature handling and improve argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Then run `npm run start <song url>`.
 - `-d <path>` - Change the download location
 -  `-h` or `--headless` - Use headless mode, which hides the UI.
 -  `-p <pitch offset>` - Change the pitch of the downloaded tracks (-1 to go down half step, 1 to go up half step, etc)
+- `--intro` - Include the intro precount
 
 Using headless mode may make it less clear what is going on behind the scenes, so I suggest testing it out
 in the regular mode first.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import {startBrowser} from "./browser.js";
-import {signIn} from "./signIn.js";
+import { startBrowser } from "./browser.js";
+import { signIn } from "./signIn.js";
 import util from "./util.js";
 import * as dotenv from 'dotenv';
 
@@ -11,11 +11,13 @@ if (!process.env.KV_USERNAME || !process.env.KV_PASSWORD) {
 }
 
 let args = process.argv;
-if (args[0] =~ /node$/) {
+if (args[0].match(/node$/)) {
   args = args.slice(2);
-} else if (args[0] =~ /npm$/) {
+} else if (args[0].match(/npm$/)) {
   args = args.slice(3);
 }
+
+console.log(args);
 
 const songUrl = args[0];
 if (!songUrl) {
@@ -28,6 +30,13 @@ if (!songUrl) {
 let downloadPath = util.getArgValue(args, "-d");
 let headless = args.includes("-h") || args.includes("--headless");
 let pitch = parseInt(util.getArgValue(args, "-p"));
+let intro = args.includes("-i") || args.includes("--intro");
+
+console.log(`Download Path: ${downloadPath}`);
+console.log(`Headless Mode: ${headless}`);
+console.log(`Pitch Value: ${pitch}`);
+console.log(`Intro Flag: ${intro}`);
+
 
 // START BROWSER
 
@@ -46,9 +55,9 @@ if (downloadPath) {
 // SIGN IN 
 console.log("Signing in...");
 const domain = new URL(songUrl).hostname;
-await page.setViewport({width: 1080, height: 1024});
+await page.setViewport({ width: 1080, height: 1024 });
 
-await signIn(page, 
+await signIn(page,
   domain,
   process.env.KV_USERNAME,
   process.env.KV_PASSWORD
@@ -76,7 +85,7 @@ if (!Number.isNaN(pitch)) {
   const pitchUpButton = await page.waitForSelector("div.pitch button.btn--pitch[title='Key up']");
   const pitchDownButton = await page.waitForSelector("div.pitch button.btn--pitch[title='Key down']");
   let diff = pitch - currentPitch;
-  
+
   let button = diff < 0 ? pitchDownButton : pitchUpButton;
   for (let index = 0; index < Math.abs(diff); index++) {
     console.debug("adjusting pitch");
@@ -86,6 +95,18 @@ if (!Number.isNaN(pitch)) {
     // need to reload after pitching
     (await page.waitForSelector("a#pitch-link")).click();
     await util.sleep(4000);
+  }
+
+}
+
+
+
+// Handling the 'precount' checkbox if intro is enabled
+if (intro) {
+  const precountCheckbox = await page.waitForSelector("#precount");
+  const isChecked = await precountCheckbox.evaluate(el => el.checked);
+  if (!isChecked) {
+    await precountCheckbox.evaluate(el => el.click());
   }
 }
 
@@ -97,7 +118,7 @@ let i = 1;
 let downloadButton = await page.waitForSelector("a.download");
 for (const soloButton of soloButtons) {
   // the click track also has the intro element, so we need to extract just the text
-  const trackName = await trackNames[i-1].evaluate(el => el.lastChild.nodeValue.trim());
+  const trackName = await trackNames[i - 1].evaluate(el => el.lastChild.nodeValue.trim());
   console.log(`soloing track ${i} of ${soloButtons.length} (${trackName})`);
   await soloButton.click();
   await util.sleep(3000);

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,6 @@ if (args[0].match(/node$/)) {
   args = args.slice(3);
 }
 
-console.log(args);
-
 const songUrl = args[0];
 if (!songUrl) {
   console.error("Usage: npm run start <song url>\n\n\t-d <path> to change the download directory\n\t-h to use headless mode")


### PR DESCRIPTION
Add intro feature handling and improve argument parsing

This commit introduces the handling of the `--intro` command line argument which controls the activation of the intro functionality in the script. The intro feature is related to managing a 'precount' checkbox on the web interface, which is now conditionally checked based on the presence of this argument.

Changes:
- Parse the `--intro` flag from command line arguments to set the `intro` boolean variable.
- Add conditional logic to check the 'precount' checkbox when the `intro` flag is true.
- Enhance the debug output to include logging for all major variables influenced by command line arguments, aiding in troubleshooting and verification of script behavior.

This enhancement ensures that users can opt into precount features dynamically via the command line, improving the script's flexibility and usability in different use cases.
